### PR TITLE
Fix CMake build with gfortran

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,29 +1,62 @@
-# Compiled Object files
-*.slo
-*.lo
-*.o
-*.obj
+# =============================
+# Developer-created directories 
+# =============================
+build
+doc
 
-# Precompiled Headers
-*.gch
-*.pch
+# =========================
+# Compiler-generated files
+# =========================
+*.[oa]   # object files and static libraries
+*.[mod]  # Fortran module interface information
+*.[smod] # Fortran submodule interface information
 
-# Compiled Dynamic libraries
-*.so
-*.dylib
-*.dll
 
-# Fortran module files
-*.mod
-*.smod
+# =========================
+# Operating System Files
+# =========================
 
-# Compiled Static libraries
-*.lai
-*.la
-*.a
-*.lib
+# macOS
+# =========================
 
-# Executables
-*.exe
-*.out
-*.app
+.DS_Store    # Finder display formatting
+.AppleDouble
+.LSOverride
+
+# Thumbnails
+._*
+
+# Files that might appear on external disk
+.Spotlight-V100
+.Trashes
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+# Temporary files from Microsoft Word or Excel
+Documents/Transient\ Documents/~$ansientSolution.docx
+.tmp
+
+# Windows image file caches
+# =========================
+Thumbs.db
+ehthumbs.db
+
+# Folder config file
+Desktop.ini
+
+# Recycle Bin used on file shares
+$RECYCLE.BIN/
+
+# Windows Installer files
+*.cab
+*.msi
+*.msm
+*.msp
+
+# Windows shortcuts
+*.lnk

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,7 +76,3 @@ endfunction(add_mpi_test)
 # Invoke the above function with the following arguments: 
 # test name, compiled program name, number of images, path to program:
 add_mpi_test(initialization_test initialization-test 4  ${CMAKE_BINARY_DIR}/src/tests/initialization-test)
-
-if(gfortran_compiler)
-else()
-endif()

--- a/src/utilities/CMakeLists.txt
+++ b/src/utilities/CMakeLists.txt
@@ -9,7 +9,7 @@ endif()
 
 add_library( icar_utils
   assertions_implementation.f90
-  assertions_interface.F90
+  assertions_interface.f90
   configuration_implementation.f90
   configuration_interface.f90
 )

--- a/src/utilities/CMakeLists.txt
+++ b/src/utilities/CMakeLists.txt
@@ -2,9 +2,9 @@ set(CMAKE_Fortran_MODULE_DIRECTORY ${CMAKE_BINARY_DIR}/mod)
 
 #Toggle C preprocessor macro for turning assertions on or off
 if(NO_ASSERTIONS)
-  add_definitions(-DUSE_ASSERTIONS=.false.)
+  set_source_files_properties(assertions_interface.f90 PROPERTIES COMPILE_FLAGS "-cpp -DUSE_ASSERTIONS=.false.")
 else()
-  add_definitions(-DUSE_ASSERTIONS=.true.)
+  set_source_files_properties(assertions_interface.f90 PROPERTIES COMPILE_FLAGS "-cpp -DUSE_ASSERTIONS=.true.")
 endif()
 
 add_library( icar_utils

--- a/src/utilities/assertions_interface.f90
+++ b/src/utilities/assertions_interface.f90
@@ -25,7 +25,7 @@ module assertions_interface
   
 ! Set the USE_ASSERTIONS constant below using the C preprocessor:
 !
-!    gfortran -DUSE_ASSERTIONS=.false. -c assertions_interface.F90 
+!    gfortran -cpp -DUSE_ASSERTIONS=.false. -c assertions_interface.f90 
 !
 ! or set the corresponding NO_ASSERTIONS variable defined in this directory's CMakeLists.txt:
 !


### PR DESCRIPTION
The CMake invocation of the C preprocessor on assertions_interface.f90 has been corrected.  The build procedures described in the [README.md] and in the build description at lines [28] and [32] in assertions_interface.f90 now work as advertised.

[README.md]: https://github.com/rouson/coarray_icar/blob/master/README.md
[28]: https://github.com/rouson/coarray_icar/blob/master/src/utilities/assertions_interface.f90#L28
[32]: https://github.com/rouson/coarray_icar/blob/master/src/utilities/assertions_interface.f90#L32 