### PR TITLE
utilities: add stubs for CO_BROADCAST() as defined in Fortran 2018

### DIFF
--- a/src/tests/Makefile
+++ b/src/tests/Makefile
@@ -1,12 +1,20 @@
 # Usage:
 #
 #    make USE_ASSERTIONS=.false. # Defaults to .true. if not provided
+#    make F18=TRUE # use the Fortran 2018 function CO_BROADCAST (disabled by
+#    default)
 
 # Example of printing a variable named "var" delimited by square braces
 # $(info $$var is [${var}])
 
 ifeq ($(USE_ASSERTIONS),)
   USE_ASSERTIONS:=.false.
+endif
+
+ifeq ($(F18),TRUE)
+  co_utils_base:=co_utilities_f18
+else
+  co_utils_base:=co_utilities
 endif
 
 ifndef NETCDF
@@ -118,7 +126,7 @@ test-ideal: \
 			$(BUILD)/configuration_interface.o		\
 			$(BUILD)/grid_interface.o				\
 			$(BUILD)/grid_implementation.o			\
-			$(BUILD)/co_utilities.o					\
+			$(BUILD)/$(co_utils_base).o					\
 			$(BUILD)/mp_driver.o					\
 			$(BUILD)/mp_thompson.o
 	$(link) $^ -o $@ $(link_flags)
@@ -137,7 +145,7 @@ test-initialization: \
 		 			 $(BUILD)/timer_interface.o				\
 					 $(BUILD)/grid_interface.o				\
 					 $(BUILD)/grid_implementation.o			\
-					 $(BUILD)/co_utilities.o				\
+					 $(BUILD)/$(co_utils_base).o				\
 					 $(BUILD)/mp_driver.o					\
 					 $(BUILD)/mp_thompson.o
 	$(link) $^ -o $@ $(link_flags)
@@ -163,7 +171,7 @@ $(BUILD)/test-initialization.o: test-initialization.f90 		\
 	$(compile) $(comp_flags) -c $< -o $@
 
 # $(BUILD)/test-bcast.o:  test-bcast.f90		\
-# 						$(BUILD)/co_utilities.o
+# 						$(BUILD)/$(co_utils_base).o
 
 $(BUILD)/test-ideal.o: 	test-ideal.f90					\
 						$(BUILD)/domain_interface.o 	\
@@ -178,7 +186,7 @@ $(BUILD)/test-timer.o: test-timer.f90 $(BUILD)/timer_interface.o
 
 
 $(BUILD)/mp_thompson.o: 				$(BUILD)/timer_interface.o			\
-										$(BUILD)/co_utilities.o
+										$(BUILD)/$(co_utils_base).o
 
 $(BUILD)/mp_driver.o: 					$(BUILD)/mp_thompson.o 				\
 										$(BUILD)/domain_interface.o

--- a/src/utilities/co_utilities_f18.f90
+++ b/src/utilities/co_utilities_f18.f90
@@ -1,0 +1,26 @@
+! Stubs for utility functions which are already standardized in Fortran 2018.
+! Few compilers support these currently, ! so we only compile them if F18=TRUE is
+! specified in the makefile.
+
+module co_util
+
+    implicit none
+
+contains
+
+    subroutine co_bcast(coarray, source_image, first_image, last_image)
+        implicit none
+        real(kind=8), intent(inout) :: coarray(:,:,:,:)[*]
+        integer, intent(in) :: source_image, first_image, last_image
+        integer :: dest_image
+
+        ! Broadcast intrinsic defined in Fortran 2018. Currently supported only by
+        ! Cray. We don't need the first_image/last_image args, but keep the function
+        ! prototype the same so we can switch between the custom version and the
+        ! standard version easily.
+
+        call co_broadcast(coarray, source_image)
+
+    end subroutine co_bcast
+
+end module co_util


### PR DESCRIPTION
Currently only the Cray compiler supports CO_BROADCAST(), but it is hugely
faster than the custom CO_BCAST() implemented in this code. Until more
compilers implement CO_BROADCAST(), keep it isolated in its own utility file
which is compiled only if F18=TRUE is set in the makefile.